### PR TITLE
MOBILE-1822: "Pull to refresh" components need to be less sensitive to pulling

### DIFF
--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -9,30 +9,30 @@
 import UIKit
 
 public enum Position {
-    
+
     case Top, Bottom
 }
 
 public class PullToRefresh: NSObject {
-    
+
     public var position: Position = .Top
-    
+
     public var animationDuration: NSTimeInterval = 1
     public var hideDelay: NSTimeInterval = 0
     public var springDamping: CGFloat = 0.4
     public var initialSpringVelocity: CGFloat = 0.8
     public var animationOptions: UIViewAnimationOptions = [.CurveLinear]
     public var refreshingOffset: CGFloat = 0.0
-    
+
     let refreshView: UIView
     var action: (() -> ())?
-    
+
     private var isObserving = false
-    
+
     public let animator: RefreshViewAnimator
-    
+
     // MARK: - ScrollView & Observing
-    
+
     private var scrollViewDefaultInsets = UIEdgeInsetsZero
     weak var scrollView: UIScrollView? {
         willSet {
@@ -45,9 +45,9 @@ public class PullToRefresh: NSObject {
             }
         }
     }
-    
+
     // MARK: - State
-    
+
     public private(set) var state: State = .Initial {
         didSet {
             animator.animateState(state)
@@ -56,7 +56,7 @@ public class PullToRefresh: NSObject {
                 if oldValue != .Loading {
                     animateLoadingState()
                 }
-                
+
             case .Finished:
                 if isCurrentlyVisible() {
                     animateFinishedState()
@@ -64,39 +64,39 @@ public class PullToRefresh: NSObject {
                     scrollView?.contentInset = self.scrollViewDefaultInsets
                     state = .Initial
                 }
-                
+
             default: break
             }
         }
     }
-    
+
     // MARK: - Initialization
-    
+
     public init(refreshView: UIView, animator: RefreshViewAnimator, position: Position) {
         self.refreshView = refreshView
         self.animator = animator
         self.position = position
     }
-    
+
     deinit {
         removeScrollViewObserving()
     }
-    
+
     // MARK: KVO
-    
+
     private var KVOContext = "PullToRefreshKVOContext"
     private let contentOffsetKeyPath = "contentOffset"
     private let contentInsetKeyPath = "contentInset"
     private let contentSizeKeyPath = "contentSize"
     private var previousScrollViewOffset: CGPoint = CGPointZero
-    
+
     override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<()>) {
         if (context == &KVOContext && keyPath == contentOffsetKeyPath && object as? UIScrollView == scrollView) {
             var offset: CGFloat
             switch position {
             case .Top:
                 offset = previousScrollViewOffset.y + scrollViewDefaultInsets.top
-                
+
             case .Bottom:
                 if scrollView!.contentSize.height > scrollView!.bounds.height {
                     offset = scrollView!.contentSize.height - previousScrollViewOffset.y - scrollView!.bounds.height
@@ -105,12 +105,12 @@ public class PullToRefresh: NSObject {
                 }
             }
             let refreshViewHeight = refreshView.frame.size.height
-            
+
             switch offset {
             case 0 where (state != .Loading): state = .Initial
             case (-refreshViewHeight - refreshingOffset)...0 where (state != .Loading && state != .Finished):
                 state = .Releasing(progress: -offset / (refreshViewHeight + refreshingOffset))
-                
+
             case -1000...(-refreshViewHeight):
                 if state == .Releasing(progress: 1) && scrollView?.dragging == false {
                     state = .Loading
@@ -127,63 +127,63 @@ public class PullToRefresh: NSObject {
             if self.state == .Initial {
                 scrollViewDefaultInsets = scrollView!.contentInset
             }
-            
+
         } else {
             super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
         }
-        
+
         previousScrollViewOffset.y = scrollView?.contentOffset.y ?? 0
     }
-    
+
     private func addScrollViewObserving() {
         guard let scrollView = scrollView where !isObserving else {
             return
         }
-        
+
         scrollView.addObserver(self, forKeyPath: contentOffsetKeyPath, options: .Initial, context: &KVOContext)
         scrollView.addObserver(self, forKeyPath: contentSizeKeyPath, options: .Initial, context: &KVOContext)
         scrollView.addObserver(self, forKeyPath: contentInsetKeyPath, options: .New, context: &KVOContext)
-        
+
         isObserving = true
     }
-    
+
     private func removeScrollViewObserving() {
         guard let scrollView = scrollView where isObserving else {
             return
         }
-        
+
         scrollView.removeObserver(self, forKeyPath: contentOffsetKeyPath, context: &KVOContext)
         scrollView.removeObserver(self, forKeyPath: contentSizeKeyPath, context: &KVOContext)
         scrollView.removeObserver(self, forKeyPath: contentInsetKeyPath, context: &KVOContext)
-        
+
         isObserving = false
     }
 }
 
 // MARK: - Start/End Refreshin
 extension PullToRefresh {
-    
+
     func startRefreshing() {
         if self.state != .Initial {
             return
         }
-        
+
         var offsetY: CGFloat
         switch position {
         case .Top:
             offsetY = -refreshView.frame.height - scrollViewDefaultInsets.top
-            
+
         case .Bottom:
             offsetY = scrollView!.contentSize.height + refreshView.frame.height + scrollViewDefaultInsets.bottom - scrollView!.bounds.height
         }
-        
+
         scrollView?.setContentOffset(CGPoint(x: 0, y: offsetY), animated: true)
         let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(0.27 * Double(NSEC_PER_SEC)))
         dispatch_after(delayTime, dispatch_get_main_queue()) { [weak self] in
             self?.state = .Loading
         }
     }
-    
+
     func endRefreshing() {
         if state == .Loading {
             state = .Finished
@@ -193,12 +193,12 @@ extension PullToRefresh {
 
 // MARK: - Animate scroll view
 private extension PullToRefresh {
-    
+
     func animateLoadingState() {
         guard let scrollView = scrollView else {
             return
         }
-        
+
         scrollView.contentOffset = previousScrollViewOffset
         scrollView.bounces = false
         UIView.animateWithDuration(0.3, animations: {
@@ -207,7 +207,7 @@ private extension PullToRefresh {
                 let insets = self.refreshView.frame.height + self.scrollViewDefaultInsets.top
                 scrollView.contentInset.top = insets
                 scrollView.contentOffset = CGPointMake(scrollView.contentOffset.x, -insets)
-                
+
             case .Bottom:
                 let insets = self.refreshView.frame.height + self.scrollViewDefaultInsets.bottom
                 scrollView.contentInset.bottom = insets
@@ -215,10 +215,10 @@ private extension PullToRefresh {
             }, completion: { finished in
                 scrollView.bounces = true
         })
-        
+
         action?()
     }
-    
+
     func animateFinishedState() {
         removeScrollViewObserving()
         UIView.animateWithDuration(
@@ -241,7 +241,7 @@ private extension PullToRefresh {
 
 // MARK: - Helpers
 private extension PullToRefresh {
-    
+
     func isCurrentlyVisible() -> Bool {
         return self.scrollView?.contentOffset.y <= -self.scrollViewDefaultInsets.top
     }

--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -22,7 +22,7 @@ public class PullToRefresh: NSObject {
     public var springDamping: CGFloat = 0.4
     public var initialSpringVelocity: CGFloat = 0.8
     public var animationOptions: UIViewAnimationOptions = [.CurveLinear]
-    public var refreshingOffset: CGFloat = 0.0
+    public var refreshOffset: CGFloat = 0
 
     let refreshView: UIView
     var action: (() -> ())?
@@ -105,11 +105,13 @@ public class PullToRefresh: NSObject {
                 }
             }
             let refreshViewHeight = refreshView.frame.size.height
+            let refreshOffset = min(self.refreshOffset + refreshViewHeight, UIScreen.mainScreen().bounds.height / 6);
+            print(refreshOffset);
 
             switch offset {
             case 0 where (state != .Loading): state = .Initial
-            case (-refreshViewHeight - refreshingOffset)...0 where (state != .Loading && state != .Finished):
-                state = .Releasing(progress: -offset / (refreshViewHeight + refreshingOffset))
+            case (-refreshOffset)...0 where (state != .Loading && state != .Finished):
+                state = .Releasing(progress: -offset / refreshOffset)
 
             case -1000...(-refreshViewHeight):
                 if state == .Releasing(progress: 1) && scrollView?.dragging == false {


### PR DESCRIPTION
[w-mobile-kit CR](https://github.com/Workiva/w-mobile-kit/pull/94)
[Wdesk-ios CR](https://github.com/Workiva/wdesk-ios/pull/1231)
## Description
- "Pull to refresh" components need to be less sensitive to pulling.
## What Was Changed
- Forked the `PullToRefresh` repo and added a `refreshingOffset` which increases the amount of you have to pull the table view to get the refresh to trigger by the height of the refresh view plus the new offset value.
- Added a direction to the `WSpinner` that will allow it to draw clockwise or counterclockwise.
- Inverted the colors of the background and the progress stroke layer of the `WSpinner` use in the `WPullToRefresh` and the indeterminate is now `0.85` instead of `0.15`. These changes are for allowing the stroke of the circle while pulling a scroll view to be green instead of grey.
- Changes to update us to the latest version of the `PullToRefresh` component.
## Testing

Follow testing instructions in `Wdesk-ios` CR.

---

Please Review: @Workiva/mobile  
