### PR TITLE
MOBILE-2203: Remove debug log from pull to refresh

### DIFF
--- a/PullToRefresh/PullToRefresh.swift
+++ b/PullToRefresh/PullToRefresh.swift
@@ -106,7 +106,6 @@ public class PullToRefresh: NSObject {
             }
             let refreshViewHeight = refreshView.frame.size.height
             let refreshOffset = min(self.refreshOffset + refreshViewHeight, UIScreen.mainScreen().bounds.height / 6);
-            print(refreshOffset);
 
             switch offset {
             case 0 where (state != .Loading): state = .Initial
@@ -137,7 +136,7 @@ public class PullToRefresh: NSObject {
         previousScrollViewOffset.y = scrollView?.contentOffset.y ?? 0
     }
 
-    private func addScrollViewObserving() {
+    public func addScrollViewObserving() {
         guard let scrollView = scrollView where !isObserving else {
             return
         }
@@ -149,7 +148,7 @@ public class PullToRefresh: NSObject {
         isObserving = true
     }
 
-    private func removeScrollViewObserving() {
+    public func removeScrollViewObserving() {
         guard let scrollView = scrollView where isObserving else {
             return
         }


### PR DESCRIPTION
## Description
- There is a left over debug log from the pull to refresh that is spamming out logs, remove it.
## What Was Changed
- Removed pull to refresh debug log
- Exposed some methods for removing kvo observers
- Calling newly exposed PTR methods to resolve crashes in automation tests
## Testing
1. Make sure you do not see a log in the console anymore.
2. Ensure when you lock the app from the sim, it does not crash.

---

Please Review: @Workiva/mobile  
